### PR TITLE
Fixed safari sidebar clipping

### DIFF
--- a/components/Sidebar/sidebar.module.scss
+++ b/components/Sidebar/sidebar.module.scss
@@ -7,7 +7,7 @@
     overflow: visible;
     position: -webkit-sticky;
     position: sticky;
-    top: 0;
+    // top: 0;
     z-index: 99;
 }
 


### PR DESCRIPTION
Safari had an issue where scrolling down to the bottom of a page (assuming the page was vertically scrollable) would case the top of the sidebar to shift downwards, clipping it. This was fixed by removing the `top: 0` CSS attribute from `.sidebar_container`. This does mean that the sidebar now has over-scroll due to how safari behaves.