### PR TITLE
Disabled horizontal scrolling

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -51,4 +51,6 @@ body {
   margin: 0;
   height: 100vh;
   overscroll-behavior: none;
+  max-width: 100%;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
In chrome browsers, there is occasionally an issue where the About page allows horizontal scrolling. I was unable to reproduce, but likely caused by the fadeInRight effect.

Possibly fixed by adding:
`body {
  max-width: 100%;
  overflow-x: hidden;
}`